### PR TITLE
Add smarctl.device-include/exclude snap options

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -2,6 +2,8 @@
 
 [ -z "$(snapctl get log.level)" ] && snapctl set log.level=info
 [ -z "$(snapctl get web.listen-address)" ] && snapctl set web.listen-address=:9633
+[ -z "$(snapctl get smartctl.device-exclude)" ] && snapctl set smartctl.device-exclude=
+[ -z "$(snapctl get smartctl.device-include)" ] && snapctl set smartctl.device-include=
 
 # Restart snap to apply new config.
 snapctl restart $SNAP_NAME

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -2,8 +2,8 @@
 
 [ -z "$(snapctl get log.level)" ] && snapctl set log.level=info
 [ -z "$(snapctl get web.listen-address)" ] && snapctl set web.listen-address=:9633
-[ -z "$(snapctl get smartctl.device-exclude)" ] && snapctl set smartctl.device-exclude=
-[ -z "$(snapctl get smartctl.device-include)" ] && snapctl set smartctl.device-include=
+[ -z "$(snapctl get smartctl.device-exclude)" ] && snapctl set smartctl.device-exclude=""
+[ -z "$(snapctl get smartctl.device-include)" ] && snapctl set smartctl.device-include=""
 
 # Restart snap to apply new config.
 snapctl restart $SNAP_NAME

--- a/snap/local/smartctl_exporter.wrapper
+++ b/snap/local/smartctl_exporter.wrapper
@@ -4,11 +4,14 @@ args=()
 
 add_option() {
     key=$1
-    value="$(snapctl get "$key")"
-    [ -n "$value" ] && args+=("--$key=$value")
+    if value="$(snapctl get "$key" 2>/dev/null)"; then
+        if [ -n "$value" ]; then
+            args+=("--$key=$value")
+        fi
+    fi
 }
 
-# Add snap config option
+# Add snap config options
 add_option log.level
 add_option web.listen-address
 add_option smartctl.device-exclude

--- a/snap/local/smartctl_exporter.wrapper
+++ b/snap/local/smartctl_exporter.wrapper
@@ -11,6 +11,8 @@ add_option() {
 # Add snap config option
 add_option log.level
 add_option web.listen-address
+add_option smartctl.device-exclude
+add_option smartctl.device-include
 
 # Start the exporter with config options
 exec "${SNAP}/bin/smartctl_exporter" \


### PR DESCRIPTION
Add the new set of snap configuration options to support including/excluding device names from auto scanning by the exporter. The configs use the upstream flags:
- `--smartctl.device-exclude=""`
- `--smartctl.device-include=""`

See the [upstream](https://github.com/prometheus-community/smartctl_exporter) for more information.

### Test example

- Install and run the snap as usual.
- Run `snap set smartctl-exporter smartctl.device-exclude="sda"` or whatever drive you have present on a system
- Run `snap restart smartctl-exporter` to apply the config
- Check the logs by running the `sudo logs smartctl-exporter.smartctl-exporter` to see if it is ignoring the scan of the `/dev/sda` device