### PR TITLE
Introduce TICS workflow

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -37,6 +37,7 @@ jobs:
         run: |
           sudo apt update
           python -m pip install --upgrade pip
+          # tics action requires flake8 to be installed on the runner
           python -m pip install flake8
           # pin tox to the current major version to avoid
           # workflows breaking all at once when a new major version is released.

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -7,7 +7,25 @@ on:
       - main
 
 jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify snap builds successfully
+        id: build
+        uses: canonical/action-build@v1
+
+      - name: Upload the built snap
+        uses: actions/upload-artifact@v4
+        with:
+          name: snap_artifact
+          path: ${{ steps.build.outputs.snap }}
+
   tics-report:
+    needs: build
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -19,20 +37,21 @@ jobs:
         run: |
           sudo apt update
           python -m pip install --upgrade pip
+          python -m pip install flake8
           # pin tox to the current major version to avoid
           # workflows breaking all at once when a new major version is released.
           python -m pip install 'tox<5'
 
-      - name: Setup Tox environment
-        run: tox --workdir /tmp/tox -e test-all --notest
+      - name: Get the snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: snap_artifact
 
-      - name: Test with tox
-        run: tox --workdir /tmp/tox run --skip-pkg-install --result-json results/tox.json -e test-all
+      - name: Test with tox and produce coverage report
+        run: tox -e test-all
 
       - name: Run TICS analysis
         uses: tiobe/tics-github-action@v3
-        env:
-          PATH: "/tmp/tox/test-all"
         with:
           mode: qserver
           project: smartctl-exporter-snap

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -38,6 +38,7 @@ jobs:
           sudo apt update
           python -m pip install --upgrade pip
           # tics action requires flake8 to be installed on the runner
+          # https://github.com/tiobe/tics-github-action/issues/410
           python -m pip install flake8
           # pin tox to the current major version to avoid
           # workflows breaking all at once when a new major version is released.

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -50,7 +50,7 @@ jobs:
           name: snap_artifact
 
       - name: Test with tox and produce coverage report
-        run: tox -e test-all
+        run: tox -e tics
 
       - name: Run TICS analysis
         uses: tiobe/tics-github-action@v3

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
     black .
     isort .
 
-[testenv:test-all]
+[testenv:tics]
 base = testenv
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,17 @@ commands =
     black .
     isort .
 
+[testenv:test-all]
+deps =
+    pytest
+    pytest-cov
+    -r {toxinidir}/tests/functional/requirements.txt
+allowlist_externals = mkdir
+commands_pre = mkdir -p tests/report
+commands =
+    pytest {toxinidir}/tests \
+    {posargs:-v --cov --cov-report=xml:tests/report/coverage.xml --junit-xml=tests/report/tests.xml}
+
 [testenv:func]
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -34,10 +34,10 @@ commands =
     isort .
 
 [testenv:tics]
-base = testenv
 deps =
     pytest
     pytest-cov
+    -r {toxinidir}/tests/functional/requirements.txt
 description = Run all tests for snap and produce coverage report
 commands =
     pytest {toxinidir}/tests \

--- a/tox.ini
+++ b/tox.ini
@@ -34,15 +34,14 @@ commands =
     isort .
 
 [testenv:test-all]
+base = testenv
 deps =
     pytest
     pytest-cov
-    -r {toxinidir}/tests/functional/requirements.txt
-allowlist_externals = mkdir
-commands_pre = mkdir -p tests/report
+description = Run all tests for snap and produce coverage report
 commands =
     pytest {toxinidir}/tests \
-    {posargs:-v --cov --cov-report=xml:tests/report/coverage.xml --junit-xml=tests/report/tests.xml}
+    -v --cov --cov-report=xml:{toxinidir}/tests/report/coverage.xml --junit-xml={toxinidir}/tests/report/tests.xml
 
 [testenv:func]
 deps =


### PR DESCRIPTION
Andrea and I already added a brain dump tics workflow YAML file during our initial testing phase. This PR fixes the workflow, allowing the TICS report to be generated every time there is a push to the main. Additionally, the workflow can be triggered manually.

Additionally, we can centrally manage the workflow later.

https://github.com/canonical/solutions-engineering-automation/issues/115