### PR TITLE
Add snap repo git revision to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,7 +79,8 @@ parts:
     override-pull: |
       craftctl default
       TAG=$(git describe --tags)
-      craftctl set version="${TAG#v}"
+      SNAP_GIT_VERSION=$(git -C $CRAFT_PROJECT_DIR describe --always --dirty --abbrev=10)
+      craftctl set version="${TAG#v}+snap-${SNAP_GIT_VERSION}"
   scripts:
     plugin: dump
     source: snap/local


### PR DESCRIPTION
This will help identify which revision
of this snap source was used to build a snap revision.

For reference, the snap will be named like this in this new pattern: `smartctl-exporter_0.12.0+snap-840e2eed2a-dirty_amd64.snap` for a dirty checkout, or `smartctl-exporter_0.12.0+snap-87b964fcf0_amd64.snap` for a clean checkout.