### PR TITLE
Bump smartctl-exporter dependency to v0.13.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
   smartctl-exporter:
     plugin: go
     source: https://github.com/prometheus-community/smartctl_exporter.git
-    source-tag: v0.12.0
+    source-tag: v0.13.0
     source-type: git
     build-snaps:
       - go


### PR DESCRIPTION
There was an [update](https://github.com/prometheus-community/smartctl_exporter/releases/tag/v0.13.0) to the smartctl-exporter dependency