### PR TITLE
feat: add support for smartctl.device

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -2,6 +2,7 @@
 
 [ -z "$(snapctl get log.level)" ] && snapctl set log.level=info
 [ -z "$(snapctl get web.listen-address)" ] && snapctl set web.listen-address=:9633
+[ -z "$(snapctl get smartctl.device)" ] && snapctl set smartctl.device=""
 [ -z "$(snapctl get smartctl.device-exclude)" ] && snapctl set smartctl.device-exclude=""
 [ -z "$(snapctl get smartctl.device-include)" ] && snapctl set smartctl.device-include=""
 

--- a/snap/local/smartctl_exporter.wrapper
+++ b/snap/local/smartctl_exporter.wrapper
@@ -11,9 +11,25 @@ add_option() {
     fi
 }
 
+# Add repeatable option (space-separated values become multiple flags)
+add_repeatable_option() {
+    key=$1
+    if value="$(snapctl get "$key" 2>/dev/null)"; then
+        if [ -n "$value" ]; then
+            read -ra devices <<< "$value"
+            for device in "${devices[@]}"; do
+                if [ -n "$device" ]; then
+                    args+=("--$key=$device")
+                fi
+            done
+        fi
+    fi
+}
+
 # Add snap config options
 add_option log.level
 add_option web.listen-address
+add_repeatable_option smartctl.device
 add_option smartctl.device-exclude
 add_option smartctl.device-include
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,9 @@ description: |
     The default is `:9633`.
   - `log.level`: the log level of the smartctl-exporter. One of: [debug, info, warn, error]
     The default is `info`.
+  - `smartctl.device`: Space-separated list of devices to monitor.
+    The exporter will scan the system for available devices if not specified.
+    Examples: `/dev/sda`, `/dev/sda;sat`, `/dev/sdm;megaraid,0`, `/dev/sda /dev/sdm;megaraid,0`
   - `smartctl.device-exclude`: Regexp of device names to exclude from automatic scanning. (mutually exclusive to device-include)
   - `smartctl.device-include`: Regexp of device names to include in automatic scanning. (mutually exclusive to device-exclude)
 


### PR DESCRIPTION
Add support for flag smartctl.device.
The snap configuration is space-separated and will be added to exporter args repeatedly.