### PR TITLE
snap: enable riscv64 builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,7 @@ platforms:
   arm64:
   s390x:
   ppc64el:
+  riscv64:
 
 apps:
   smartctl-exporter:


### PR DESCRIPTION
The snap works fine on riscv64 and provides the expected online report including extensive information about NVMe drives.

Just add riscv64 to the list of platforms.